### PR TITLE
update bot and create session repository and model for multiple sessions

### DIFF
--- a/app/bot/controllers/bot_events_controller.rb
+++ b/app/bot/controllers/bot_events_controller.rb
@@ -1,46 +1,42 @@
 class BotEventsController
   def initialize
     @bot_events_view = BotEventsView.new
-    @find_event_data = {}
-    @create_event_data = {}
   end
-
 
   # Find Event
-
-  def set_address_around_me(message)
-    @find_event_data[:address] = "Bordeaux, France"
+  def set_address_around_me(session, message)
+    session.find_event_data[:address] = "Bordeaux, France"
   end
 
-  def set_address(message)
-    @find_event_data[:address] = message.text
+  def set_address(session, message)
+    session.find_event_data[:address] = message.text
   end
 
-  def set_find_date(postback)
+  def set_find_date(session, postback)
     if postback.payload ==  'find_date_today'
-      @find_event_data[:today] = true
+      session.find_event_data[:today] = true
     elsif postback.payload ==  'find_date_later'
-      @find_event_data[:today] = false
+      session.find_event_data[:today] = false
     end
   end
 
-  def set_find_activity(postback)
-    @find_event_data[:activity] = postback.payload.split.last
+  def set_find_activity(session, postback)
+    session.find_event_data[:activity] = postback.payload.split.last
   end
 
-  def index(postback)
-    if @find_event_data[:activity] == "Surprise"
-      if @find_event_data[:today]
-        events = Event.where("start_at <= ?", Date.tomorrow.midnight).near(@find_event_data[:address], 10)
+  def index(session, postback)
+    if session.find_event_data[:activity] == "Surprise"
+      if session.find_event_data[:today]
+        events = Event.where("start_at <= ?", Date.tomorrow.midnight).near(session.find_event_data[:address], 10)
       else
-        events = Event.where("start_at > ?", Date.tomorrow.midnight).near(@find_event_data[:address], 10)
+        events = Event.where("start_at > ?", Date.tomorrow.midnight).near(session.find_event_data[:address], 10)
       end
     else
-      activity = Activity.find_by(name: @find_event_data[:activity])
-      if @find_event_data[:today]
-        events = Event.where("start_at <= ? and activity_id =?", Date.today.midnight, activity).near(@find_event_data[:address], 10)
+      activity = Activity.find_by(name: session.find_event_data[:activity])
+      if session.find_event_data[:today]
+        events = Event.where("start_at <= ? and activity_id =?", Date.today.midnight, activity).near(session.find_event_data[:address], 10)
       else
-        events = Event.where("start_at > ? and activity_id =?", Date.today.midnight, activity).near(@find_event_data[:address], 10)
+        events = Event.where("start_at > ? and activity_id =?", Date.today.midnight, activity).near(session.find_event_data[:address], 10)
       end
     end
     @bot_events_view.show_list(events, postback)
@@ -49,116 +45,116 @@ class BotEventsController
 
   # Create Event
 
-  def gets_day(postback)
+  def gets_day(session, postback)
     @bot_events_view.choose_now_or_later(postback)
   end
 
-  def set_date_today(postback)
-    @create_event_data[:date] = Date.today
+  def set_date_today(session, postback)
+    session.create_event_data[:date] = Date.today
   end
 
-  def gets_date(postback)
+  def gets_date(session, postback)
     @bot_events_view.choose_date(postback)
   end
 
-  def set_create_date(message)
+  def set_create_date(session, message)
     date = Time.parse(message.text)
     if date < Date.today
       @bot_events_view.choose_later_start_date(message)
       return false
     else
-      @create_event_data[:date] = Date.parse(message.text)
+      session.create_event_data[:date] = Date.parse(message.text)
       return true
     end
   end
 
-  def gets_start_time(postback)
+  def gets_start_time(session, postback)
     @bot_events_view.choose_start_time(postback)
   end
 
-  def set_start_time(message)
-    @create_event_data[:start_time] = Time.parse(message.text)
+  def set_start_time(session, message)
+    session.create_event_data[:start_time] = Time.parse(message.text)
   end
 
-  def gets_end_time(message)
+  def gets_end_time(session, message)
     @bot_events_view.choose_end_time(message)
   end
 
-  def set_end_time(message)
-    @create_event_data[:end_time] = Time.parse(message.text)
+  def set_end_time(session, message)
+    session.create_event_data[:end_time] = Time.parse(message.text)
   end
 
-  def gets_activity_1(message)
+  def gets_activity_1(session, message)
     @bot_events_view.full_list_1(message)
   end
 
-  def gets_activity_2(postback)
+  def gets_activity_2(session, postback)
     @bot_events_view.full_list_2(postback)
   end
 
-  def gets_activity_3(postback)
+  def gets_activity_3(session, postback)
     @bot_events_view.full_list_3(postback)
   end
 
-  def gets_activity_4(postback)
+  def gets_activity_4(session, postback)
     @bot_events_view.full_list_4(postback)
   end
 
-  def gets_activity_5(postback)
+  def gets_activity_5(session, postback)
     @bot_events_view.full_list_5(postback)
   end
 
-  def set_create_activity(postback)
-    @create_event_data[:activity] = postback.payload.split.last
+  def set_create_activity(session, postback)
+    session.create_event_data[:activity] = postback.payload.split.last
   end
 
-  def gets_address(message)
+  def gets_address(session, message)
     @bot_events_view.enter_address(message)
   end
 
-  def set_create_address(message)
-    @create_event_data[:address] = message.text
+  def set_create_address(session, message)
+    session.create_event_data[:address] = message.text
   end
 
-  def gets_level(message)
+  def gets_level(session, message)
     @bot_events_view.choose_level(message)
   end
 
-  def set_level(postback)
-    @create_event_data[:level] = postback.payload.split.last
+  def set_level(session, postback)
+    session.create_event_data[:level] = postback.payload.split.last
   end
 
-  def gets_max_participants(postback)
+  def gets_max_participants(session, postback)
     @bot_events_view.enter_max_participants(postback)
   end
 
-  def set_max_participants(message)
-    @create_event_data[:max_participants] = message.text
+  def set_max_participants(session, message)
+    session.create_event_data[:max_participants] = message.text
   end
 
-  def gets_event_description(postback)
+  def gets_event_description(session, postback)
     @bot_events_view.enter_event_description(postback)
   end
 
-  def set_event_description(message)
-    @create_event_data[:description] = message.text
+  def set_event_description(session, message)
+    session.create_event_data[:description] = message.text
   end
 
-  def create(message)
-    d = @create_event_data[:date]
-    st = @create_event_data[:start_time]
-    et = @create_event_data[:end_time]
-    @create_event_data[:start_at] = DateTime.new(d.year, d.month, d.day, st.hour, st.min)
-    @create_event_data[:end_at] = DateTime.new(d.year, d.month, d.day, et.hour, et.min)
-    activity = Activity.find_by(name: @create_event_data[:activity])
+  def create(session, message)
+    d = session.create_event_data[:date]
+    st = session.create_event_data[:start_time]
+    et = session.create_event_data[:end_time]
+    session.create_event_data[:start_at] = DateTime.new(d.year, d.month, d.day, st.hour, st.min)
+    session.create_event_data[:end_at] = DateTime.new(d.year, d.month, d.day, et.hour, et.min)
+    activity = Activity.find_by(name: session.create_event_data[:activity])
     Event.create(
-      start_at: @create_event_data[:start_at],
-      end_at: @create_event_data[:end_at],
+      start_at: session.create_event_data[:start_at],
+      end_at: session.create_event_data[:end_at],
       activity: activity,
-      address: @create_event_data[:address],
-      level: @create_event_data[:level],
-      max_participants: @create_event_data[:max_participants],
-      description: @create_event_data[:description],
+      address: session.create_event_data[:address],
+      level: session.create_event_data[:level],
+      max_participants: session.create_event_data[:max_participants],
+      description: session.create_event_data[:description],
       user: User.last
 
       )

--- a/app/bot/controllers/bot_threads_controller.rb
+++ b/app/bot/controllers/bot_threads_controller.rb
@@ -3,27 +3,27 @@ class BotThreadsController
     @bot_threads_view = BotThreadsView.new
   end
 
-  def welcome(message)
+  def welcome(session, message)
     @bot_threads_view.welcome_message(message)
   end
 
-  def initial_choice(message)
+  def initial_choice(session, message)
     @bot_threads_view.initial_choice(message)
   end
 
-  def gets_location(postback)
+  def gets_location(session, postback)
     @bot_threads_view.location(postback)
   end
 
-  def gets_address(postback)
+  def gets_address(session, postback)
     @bot_threads_view.address(postback)
   end
 
-  def gets_day(postback)
+  def gets_day(session, postback)
     @bot_threads_view.now_or_later(postback)
   end
 
-  def gets_activity(postback)
+  def gets_activity(session, postback)
     @bot_threads_view.activity_list(postback)
   end
 

--- a/app/bot/models/bot_user_sessions.rb
+++ b/app/bot/models/bot_user_sessions.rb
@@ -1,0 +1,22 @@
+class BotUserSession
+  attr_accessor :find_event_data, :create_event_data, :find_address_required,
+                :create_date_required, :create_start_time_required,
+                :create_end_time_required, :create_address_required,
+                :create_max_participants_required, :create_event_description_required
+
+  def initialize
+    @find_event_data = {}
+    @create_event_data = {}
+
+    # Find event variables
+    @find_address_required = false
+
+    # Create event variable
+    @create_date_required = false
+    @create_start_time_required = false
+    @create_end_time_required = false
+    @create_address_required = false
+    @create_max_participants_required = false
+    @create_event_description_required = false
+  end
+end

--- a/app/bot/repositories/bot_user_session_repository.rb
+++ b/app/bot/repositories/bot_user_session_repository.rb
@@ -1,0 +1,14 @@
+class BotUserSessionRepository
+  @@sessions = {}
+
+  def self.find_or_create(session_id)
+    unless @@sessions.has_key?(session_id)
+      @@sessions[session_id] = BotUserSession.new
+    end
+    @@sessions[session_id]
+  end
+
+  def self.create(session_id)
+    @@sessions[session_id] = BotUserSession.new
+  end
+end


### PR DESCRIPTION
Après discussion avec Audrey, Pierre et David (copains dev) hier soir, on s'est rendues compte avec Audrey que le système mis en place vendredi ne nous permet pas d'avoir des sessions multiples, c'est à dire plusieurs utilisateurs à la fois. On s'est dis que ça pourrait être cool pour le demo d'avoir le choix d'avoir plusieurs utilisateurs ou pas, et donc après BEAUCOUP de bugs et des gros mots et des cries, et quelques larmes 😢 😱 😰... j'ai mis en place quelques trucs pour permettre des 'multiple sessions'. Pierre m'avait expliqué comment faire, et ensuite je me suis inspirée du Food Delivery (dans lequel on avait des repos comme étape intermédiaire avant le "base de données" (nos fichiers csv). 

Je vous détaille ci-dessous ce que j'ai fait, mais je suggère qu'on ne merge pas avant demain matin, afin que je puisse vous montrer le code et @mthbo puisse verifier que cela ne provoquera pas de problèmes pour son travail sur les utilisateurs. A mon avis, ce que j'ai mis en place facilitera la question des ids, mais afin que tout le monde soit sur le même page (si cette expression marche en français comme en anglais...) si on ne merge pas ce soir, on peut voir le code ensemble demain matin et vous pouvez le valider. Donc: 

1. j'ai crée a **BotUserSessionRepository** avec un hash vide **sessions** et deux méthodes de classe: 
- méthode de classe: **find_or_create** qui est appelé par bot.rb sur chaque message lors de son passage dans le each,  afin de verifier s'il y a déjà une session en cours. L'ID de la session est l'ID du message réçu par le bot, et il devient le clef pour cet hash **sessions**. En tant que valeur, cet hash contient toutes les données rentrées par l'utilisateur, ainsi que sa position dans le flow du bot. Auparavant, la position dans le flow du bot était géré par les booleans, et les données rentrées par l'utilisateur par les variables d'instances (d'où le problème dès qu'il y avait plus qu'un seul utilisateur). 
- méthode de classe: **create** qui est appelé par le bot.rb lorsque l'utilisateur choisit 'start_again', afin d'effacer les données qu'il aura rentré lors de sa session. 
_[Pour info le @@ devant sessions veut dire une variable de classe, il marche de même manière que les variables d'instance...sauf qu'il n'a pas besoin d'une instance. Merci codeschool.com 🙏🏽]_

2.  J'ai crée un model **BotUserSession** qui est appelé par le méthode de classe **find_or_create** dans le BotUserSessionRepository. Le fait de créer un model nous permet de appeler les méthodes sur les instance du session, plutôt que de tout stocker dans des énormes hash. Ce model est initialisé avec deux types de données: 
- le hash vide pour find_event_data et create_event_data, soit les données que l'utilisateur à rentrées; 
- les booleans qui nous permettent de déclencher les actions suivantes et, maintenant, garder une visibilité de l'avancement de l'utilisateur dans le parcours à travers le bot. 

J'espère que c'est clair et que je n'ai pas fait des conneries. Normalement il n'y a qu'une bug qui se produise lorsque l'utilisateur re-sélectionne une activité s'il ne trouve pas ce qu'il a envie de faire. Mais ce bug je ne réussis plus à le reproduire, donc peut-être que je l'ai imaginé ou qu'il est parti en weekend. 